### PR TITLE
Fix broken link to Zilliz

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Zilliz is a managed cloud-native vector database designed for the billion scale.
 - Separated storage and compute
 - Multi-language SDK's
 
-Find more information [here](www.zilliz.com).
+Find more information [here](https://zilliz.com).
 
 **Self Hosted vs SaaS**
 


### PR DESCRIPTION
The current link is a relative link so resolves to https://github.com/openai/chatgpt-retrieval-plugin/blob/main/www.zilliz.com which gives a 404.