### PR TITLE
Upgrade syntax to 3.10+

### DIFF
--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
 import asyncio
 
 from models.models import (
@@ -16,8 +15,8 @@ from services.openai import get_embeddings
 
 class DataStore(ABC):
     async def upsert(
-        self, documents: List[Document], chunk_token_size: Optional[int] = None
-    ) -> List[str]:
+        self, documents: list[Document], chunk_token_size: int | None = None
+    ) -> list[str]:
         """
         Takes in a list of documents and inserts them into the database.
         First deletes all the existing vectors with the document id (if necessary, depends on the vector db), then inserts the new ones.
@@ -42,7 +41,7 @@ class DataStore(ABC):
         return await self._upsert(chunks)
 
     @abstractmethod
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """
         Takes in a list of list of document chunks and inserts them into the database.
         Return a list of document ids.
@@ -50,7 +49,7 @@ class DataStore(ABC):
 
         raise NotImplementedError
 
-    async def query(self, queries: List[Query]) -> List[QueryResult]:
+    async def query(self, queries: list[Query]) -> list[QueryResult]:
         """
         Takes in a list of queries and filters and returns a list of query results with matching document chunks and scores.
         """
@@ -65,7 +64,7 @@ class DataStore(ABC):
         return await self._query(queries_with_embeddings)
 
     @abstractmethod
-    async def _query(self, queries: List[QueryWithEmbedding]) -> List[QueryResult]:
+    async def _query(self, queries: list[QueryWithEmbedding]) -> list[QueryResult]:
         """
         Takes in a list of queries with embeddings and filters and returns a list of query results with matching document chunks and scores.
         """
@@ -74,9 +73,9 @@ class DataStore(ABC):
     @abstractmethod
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """
         Removes vectors by ids, filter, or everything in the datastore.

--- a/datastore/providers/milvus_datastore.py
+++ b/datastore/providers/milvus_datastore.py
@@ -1,7 +1,6 @@
 import os
 import asyncio
 
-from typing import Dict, List, Optional
 from pymilvus import (
     Collection,
     connections,
@@ -95,9 +94,9 @@ SCHEMA = [
 class MilvusDataStore(DataStore):
     def __init__(
         self,
-        create_new: Optional[bool] = False,
-        index_params: Optional[dict] = None,
-        search_params: Optional[dict] = None,
+        create_new: bool | None = False,
+        index_params: dict | None = None,
+        search_params: dict | None = None,
     ):
         """Create a Milvus DataStore.
 
@@ -221,7 +220,7 @@ class MilvusDataStore(DataStore):
 
         self.col.load()
 
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """Upsert chunks into the datastore.
 
         Args:
@@ -234,7 +233,7 @@ class MilvusDataStore(DataStore):
             List[str]: The document_id's that were inserted.
         """
         # The doc id's to return for the upsert
-        doc_ids: List[str] = []
+        doc_ids: list[str] = []
         # List to collect all the insert data
         insert_data = [[] for _ in range(len(SCHEMA) - 1)]
         # Go through each document chunklist and grab the data
@@ -272,7 +271,7 @@ class MilvusDataStore(DataStore):
 
         return doc_ids
 
-    def _get_values(self, chunk: DocumentChunk) -> List[any] | None:  # type: ignore
+    def _get_values(self, chunk: DocumentChunk) -> list[any] | None:  # type: ignore
         """Convert the chunk into a list of values to insert whose indexes align with fields.
 
         Args:
@@ -310,8 +309,8 @@ class MilvusDataStore(DataStore):
 
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """Query the QueryWithEmbedding against the MilvusDocumentSearch
 
         Search the embedding and its filter in the collection.
@@ -372,16 +371,16 @@ class MilvusDataStore(DataStore):
 
             return QueryResult(query=query.query, results=results)
 
-        results: List[QueryResult] = await asyncio.gather(
+        results: list[QueryResult] = await asyncio.gather(
             *[_single_query(query) for query in queries]
         )
         return results
 
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """Delete the entities based either on the chunk_id of the vector,
 
@@ -441,7 +440,7 @@ class MilvusDataStore(DataStore):
 
         return True
 
-    def _get_filter(self, filter: DocumentMetadataFilter) -> Optional[str]:
+    def _get_filter(self, filter: DocumentMetadataFilter) -> str | None:
         """Converts a DocumentMetdataFilter to the expression that Milvus takes.
 
         Args:

--- a/datastore/providers/pinecone_datastore.py
+++ b/datastore/providers/pinecone_datastore.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 import pinecone
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 import asyncio
@@ -65,13 +65,13 @@ class PineconeDataStore(DataStore):
                 raise e
 
     @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """
         Takes in a dict from document id to list of document chunks and inserts them into the index.
         Return a list of document ids.
         """
         # Initialize a list of ids to return
-        doc_ids: List[str] = []
+        doc_ids: list[str] = []
         # Initialize a list of vectors to upsert
         vectors = []
         # Loop through the dict items
@@ -109,8 +109,8 @@ class PineconeDataStore(DataStore):
     @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """
         Takes in a list of queries with embeddings and filters and returns a list of query results with matching document chunks and scores.
         """
@@ -135,7 +135,7 @@ class PineconeDataStore(DataStore):
                 print(f"Error querying index: {e}")
                 raise e
 
-            query_results: List[DocumentChunkWithScore] = []
+            query_results: list[DocumentChunkWithScore] = []
             for result in query_response.matches:
                 score = result.score
                 metadata = result.metadata
@@ -165,7 +165,7 @@ class PineconeDataStore(DataStore):
             return QueryResult(query=query.query, results=query_results)
 
         # Use asyncio.gather to run multiple _single_query coroutines concurrently and collect their results
-        results: List[QueryResult] = await asyncio.gather(
+        results: list[QueryResult] = await asyncio.gather(
             *[_single_query(query) for query in queries]
         )
 
@@ -174,9 +174,9 @@ class PineconeDataStore(DataStore):
     @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """
         Removes vectors by ids, filter, or everything from the index.
@@ -218,8 +218,8 @@ class PineconeDataStore(DataStore):
         return True
 
     def _get_pinecone_filter(
-        self, filter: Optional[DocumentMetadataFilter] = None
-    ) -> Dict[str, Any]:
+        self, filter: DocumentMetadataFilter | None = None
+    ) -> dict[str, Any]:
         if filter is None:
             return {}
 
@@ -242,8 +242,8 @@ class PineconeDataStore(DataStore):
         return pinecone_filter
 
     def _get_pinecone_metadata(
-        self, metadata: Optional[DocumentChunkMetadata] = None
-    ) -> Dict[str, Any]:
+        self, metadata: DocumentChunkMetadata | None = None
+    ) -> dict[str, Any]:
         if metadata is None:
             return {}
 

--- a/datastore/providers/qdrant_datastore.py
+++ b/datastore/providers/qdrant_datastore.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from typing import Dict, List, Optional
 
 from grpc._channel import _InactiveRpcError
 from qdrant_client.http.exceptions import UnexpectedResponse
@@ -32,7 +31,7 @@ class QdrantDataStore(DataStore):
 
     def __init__(
         self,
-        collection_name: Optional[str] = None,
+        collection_name: str | None = None,
         vector_size: int = 1536,
         distance: str = "Cosine",
         recreate_collection: bool = False,
@@ -57,7 +56,7 @@ class QdrantDataStore(DataStore):
         # Set up the collection so the points might be inserted or queried
         self._set_up_collection(vector_size, distance, recreate_collection)
 
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """
         Takes in a list of document chunks and inserts them into the database.
         Return a list of document ids.
@@ -76,8 +75,8 @@ class QdrantDataStore(DataStore):
 
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """
         Takes in a list of queries with embeddings and filters and returns a list of query results with matching document chunks and scores.
         """
@@ -101,9 +100,9 @@ class QdrantDataStore(DataStore):
 
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """
         Removes vectors by ids, filter, or everything in the datastore.
@@ -146,7 +145,7 @@ class QdrantDataStore(DataStore):
             },
         )
 
-    def _create_document_chunk_id(self, external_id: Optional[str]) -> str:
+    def _create_document_chunk_id(self, external_id: str | None) -> str:
         if external_id is None:
             return uuid.uuid4().hex
         return uuid.uuid5(self.UUID_NAMESPACE, external_id).hex
@@ -164,9 +163,9 @@ class QdrantDataStore(DataStore):
 
     def _convert_metadata_filter_to_qdrant_filter(
         self,
-        metadata_filter: Optional[DocumentMetadataFilter] = None,
-        ids: Optional[List[str]] = None,
-    ) -> Optional[rest.Filter]:
+        metadata_filter: DocumentMetadataFilter | None = None,
+        ids: list[str] | None = None,
+    ) -> rest.Filter | None:
         if metadata_filter is None and ids is None:
             return None
 

--- a/datastore/providers/redis_datastore.py
+++ b/datastore/providers/redis_datastore.py
@@ -14,7 +14,6 @@ from redis.commands.search.field import (
     NumericField,
     VectorField,
 )
-from typing import Dict, List, Optional
 from datastore.datastore import DataStore
 from models.models import (
     DocumentChunk,
@@ -232,7 +231,7 @@ class RedisDataStore(DataStore):
             .dialect(2)
         )
 
-    async def _redis_delete(self, keys: List[str]):
+    async def _redis_delete(self, keys: list[str]):
         """
         Delete a list of keys from Redis.
 
@@ -244,13 +243,13 @@ class RedisDataStore(DataStore):
 
     #######
 
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """
         Takes in a list of list of document chunks and inserts them into the database.
         Return a list of document ids.
         """
         # Initialize a list of ids to return
-        doc_ids: List[str] = []
+        doc_ids: list[str] = []
 
         # Loop through the dict items
         for doc_id, chunk_list in chunks.items():
@@ -275,14 +274,14 @@ class RedisDataStore(DataStore):
 
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """
         Takes in a list of queries with embeddings and filters and
         returns a list of query results with matching document chunks and scores.
         """
         # Prepare results object
-        results: List[QueryResult] = []
+        results: list[QueryResult] = []
 
         # Use asyncio for concurrent search
         n = min(len(queries), 50)
@@ -311,7 +310,7 @@ class RedisDataStore(DataStore):
         for query, query_response in zip(queries, query_responses):
 
             # Iterate through nearest neighbor documents
-            query_results: List[DocumentChunkWithScore] = []
+            query_results: list[DocumentChunkWithScore] = []
             for doc in query_response.docs:
                 # Create a document chunk with score object with the result data
                 doc_json = json.loads(doc.json)
@@ -327,14 +326,14 @@ class RedisDataStore(DataStore):
             results.append(QueryResult(query=query.query, results=query_results))
         return results
 
-    async def _find_keys(self, pattern: str) -> List[str]:
+    async def _find_keys(self, pattern: str) -> list[str]:
         return await self.client.keys(pattern=pattern)
 
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """
         Removes vectors by ids, filter, or everything in the datastore.

--- a/datastore/providers/weaviate_datastore.py
+++ b/datastore/providers/weaviate_datastore.py
@@ -1,6 +1,5 @@
 # TODO
 import asyncio
-from typing import Dict, List, Optional
 from loguru import logger
 from weaviate import Client
 import weaviate
@@ -88,7 +87,7 @@ def extract_schema_properties(schema):
 
 
 class WeaviateDataStore(DataStore):
-    def handle_errors(self, results: Optional[List[dict]]) -> List[str]:
+    def handle_errors(self, results: list[dict] | None) -> list[str]:
         if not self or not results:
             return []
 
@@ -147,7 +146,7 @@ class WeaviateDataStore(DataStore):
         else:
             return None
 
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """
         Takes in a list of list of document chunks and inserts them into the database.
         Return a list of document ids.
@@ -188,8 +187,8 @@ class WeaviateDataStore(DataStore):
 
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """
         Takes in a list of queries with embeddings and filters and returns a list of query results with matching document chunks and scores.
         """
@@ -239,7 +238,7 @@ class WeaviateDataStore(DataStore):
                     .do()
                 )
 
-            query_results: List[DocumentChunkWithScore] = []
+            query_results: list[DocumentChunkWithScore] = []
             response = result["data"]["Get"][WEAVIATE_INDEX]
 
             for resp in response:
@@ -264,9 +263,9 @@ class WeaviateDataStore(DataStore):
 
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         # TODO
         """

--- a/datastore/providers/zilliz_datastore.py
+++ b/datastore/providers/zilliz_datastore.py
@@ -1,7 +1,6 @@
 import os
 import asyncio
 
-from typing import Dict, List, Optional
 from pymilvus import (
     Collection,
     connections,
@@ -92,7 +91,7 @@ SCHEMA = [
 
 
 class ZillizDataStore(DataStore):
-    def __init__(self, create_new: Optional[bool] = False):
+    def __init__(self, create_new: bool | None = False):
         """Create a Zilliz DataStore.
 
         The Zilliz Datastore allows for storing your indexes and metadata within a Zilliz Cloud instance.
@@ -154,7 +153,7 @@ class ZillizDataStore(DataStore):
 
         self.col.load()
 
-    async def _upsert(self, chunks: Dict[str, List[DocumentChunk]]) -> List[str]:
+    async def _upsert(self, chunks: dict[str, list[DocumentChunk]]) -> list[str]:
         """Upsert chunks into the datastore.
 
         Args:
@@ -167,7 +166,7 @@ class ZillizDataStore(DataStore):
             List[str]: The document_id's that were inserted.
         """
         # The doc id's to return for the upsert
-        doc_ids: List[str] = []
+        doc_ids: list[str] = []
         # List to collect all the insert data
         insert_data = [[] for _ in range(len(SCHEMA) - 1)]
         # Go through each document chunklist and grab the data
@@ -206,7 +205,7 @@ class ZillizDataStore(DataStore):
 
         return doc_ids
 
-    def _get_values(self, chunk: DocumentChunk) -> List[any] | None:  # type: ignore
+    def _get_values(self, chunk: DocumentChunk) -> list[any] | None:  # type: ignore
         """Convert the chunk into a list of values to insert whose indexes align with fields.
 
         Args:
@@ -244,8 +243,8 @@ class ZillizDataStore(DataStore):
 
     async def _query(
         self,
-        queries: List[QueryWithEmbedding],
-    ) -> List[QueryResult]:
+        queries: list[QueryWithEmbedding],
+    ) -> list[QueryResult]:
         """Query the QueryWithEmbedding against the ZillizDocumentSearch
 
         Search the embedding and its filter in the collection.
@@ -306,16 +305,16 @@ class ZillizDataStore(DataStore):
 
             return QueryResult(query=query.query, results=results)
 
-        results: List[QueryResult] = await asyncio.gather(
+        results: list[QueryResult] = await asyncio.gather(
             *[_single_query(query) for query in queries]
         )
         return results
 
     async def delete(
         self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[DocumentMetadataFilter] = None,
-        delete_all: Optional[bool] = None,
+        ids: list[str] | None = None,
+        filter: DocumentMetadataFilter | None = None,
+        delete_all: bool | None = None,
     ) -> bool:
         """Delete the entities based either on the chunk_id of the vector,
 
@@ -375,7 +374,7 @@ class ZillizDataStore(DataStore):
 
         return True
 
-    def _get_filter(self, filter: DocumentMetadataFilter) -> Optional[str]:
+    def _get_filter(self, filter: DocumentMetadataFilter) -> str | None:
         """Converts a DocumentMetdataFilter to the expression that Zilliz takes.
 
         Args:

--- a/models/api.py
+++ b/models/api.py
@@ -6,29 +6,28 @@ from models.models import (
     QueryResult,
 )
 from pydantic import BaseModel
-from typing import List, Optional
 
 
 class UpsertRequest(BaseModel):
-    documents: List[Document]
+    documents: list[Document]
 
 
 class UpsertResponse(BaseModel):
-    ids: List[str]
+    ids: list[str]
 
 
 class QueryRequest(BaseModel):
-    queries: List[Query]
+    queries: list[Query]
 
 
 class QueryResponse(BaseModel):
-    results: List[QueryResult]
+    results: list[QueryResult]
 
 
 class DeleteRequest(BaseModel):
-    ids: Optional[List[str]] = None
-    filter: Optional[DocumentMetadataFilter] = None
-    delete_all: Optional[bool] = False
+    ids: list[str] | None = None
+    filter: DocumentMetadataFilter | None = None
+    delete_all: bool | None = False
 
 
 class DeleteResponse(BaseModel):

--- a/models/models.py
+++ b/models/models.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from typing import List, Optional
 from enum import Enum
 
 
@@ -10,22 +9,22 @@ class Source(str, Enum):
 
 
 class DocumentMetadata(BaseModel):
-    source: Optional[Source] = None
-    source_id: Optional[str] = None
-    url: Optional[str] = None
-    created_at: Optional[str] = None
-    author: Optional[str] = None
+    source: Source | None = None
+    source_id: str | None = None
+    url: str | None = None
+    created_at: str | None = None
+    author: str | None = None
 
 
 class DocumentChunkMetadata(DocumentMetadata):
-    document_id: Optional[str] = None
+    document_id: str | None = None
 
 
 class DocumentChunk(BaseModel):
-    id: Optional[str] = None
+    id: str | None = None
     text: str
     metadata: DocumentChunkMetadata
-    embedding: Optional[List[float]] = None
+    embedding: list[float] | None = None
 
 
 class DocumentChunkWithScore(DocumentChunk):
@@ -33,34 +32,34 @@ class DocumentChunkWithScore(DocumentChunk):
 
 
 class Document(BaseModel):
-    id: Optional[str] = None
+    id: str | None = None
     text: str
-    metadata: Optional[DocumentMetadata] = None
+    metadata: DocumentMetadata | None = None
 
 
 class DocumentWithChunks(Document):
-    chunks: List[DocumentChunk]
+    chunks: list[DocumentChunk]
 
 
 class DocumentMetadataFilter(BaseModel):
-    document_id: Optional[str] = None
-    source: Optional[Source] = None
-    source_id: Optional[str] = None
-    author: Optional[str] = None
-    start_date: Optional[str] = None  # any date string format
-    end_date: Optional[str] = None  # any date string format
+    document_id: str | None = None
+    source: Source | None = None
+    source_id: str | None = None
+    author: str | None = None
+    start_date: str | None = None  # any date string format
+    end_date: str | None = None  # any date string format
 
 
 class Query(BaseModel):
     query: str
-    filter: Optional[DocumentMetadataFilter] = None
-    top_k: Optional[int] = 3
+    filter: DocumentMetadataFilter | None = None
+    top_k: int | None = 3
 
 
 class QueryWithEmbedding(Query):
-    embedding: List[float]
+    embedding: list[float]
 
 
 class QueryResult(BaseModel):
     query: str
-    results: List[DocumentChunkWithScore]
+    results: list[DocumentChunkWithScore]

--- a/services/chunks.py
+++ b/services/chunks.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Optional, Tuple
 import uuid
 from models.models import Document, DocumentChunk, DocumentChunkMetadata
 
@@ -19,7 +18,7 @@ EMBEDDINGS_BATCH_SIZE = 128  # The number of embeddings to request at a time
 MAX_NUM_CHUNKS = 10000  # The maximum number of chunks to generate from a text
 
 
-def get_text_chunks(text: str, chunk_token_size: Optional[int]) -> List[str]:
+def get_text_chunks(text: str, chunk_token_size: int | None) -> list[str]:
     """
     Split a text into chunks of ~CHUNK_SIZE tokens, based on punctuation and newline boundaries.
 
@@ -101,8 +100,8 @@ def get_text_chunks(text: str, chunk_token_size: Optional[int]) -> List[str]:
 
 
 def create_document_chunks(
-    doc: Document, chunk_token_size: Optional[int]
-) -> Tuple[List[DocumentChunk], str]:
+    doc: Document, chunk_token_size: int | None
+) -> tuple[list[DocumentChunk], str]:
     """
     Create a list of document chunks from a document object and return the document id.
 
@@ -151,8 +150,8 @@ def create_document_chunks(
 
 
 def get_document_chunks(
-    documents: List[Document], chunk_token_size: Optional[int]
-) -> Dict[str, List[DocumentChunk]]:
+    documents: list[Document], chunk_token_size: int | None
+) -> dict[str, list[DocumentChunk]]:
     """
     Convert a list of documents into a dictionary from document id to list of document chunks.
 
@@ -165,10 +164,10 @@ def get_document_chunks(
         with text, metadata, and embedding attributes.
     """
     # Initialize an empty dictionary of lists of chunks
-    chunks: Dict[str, List[DocumentChunk]] = {}
+    chunks: dict[str, list[DocumentChunk]] = {}
 
     # Initialize an empty list of all chunks
-    all_chunks: List[DocumentChunk] = []
+    all_chunks: list[DocumentChunk] = []
 
     # Loop over each document and create chunks
     for doc in documents:
@@ -185,7 +184,7 @@ def get_document_chunks(
         return {}
 
     # Get all the embeddings for the document chunks in batches, using get_embeddings
-    embeddings: List[List[float]] = []
+    embeddings: list[list[float]] = []
     for i in range(0, len(all_chunks), EMBEDDINGS_BATCH_SIZE):
         # Get the text of the chunks in the current batch
         batch_texts = [

--- a/services/extract_metadata.py
+++ b/services/extract_metadata.py
@@ -1,10 +1,9 @@
 from models.models import Source
 from services.openai import get_chat_completion
 import json
-from typing import Dict
 
 
-def extract_metadata_from_document(text: str) -> Dict[str, str]:
+def extract_metadata_from_document(text: str) -> dict[str, str]:
     sources = Source.__members__.keys()
     sources_string = ", ".join(sources)
     # This prompt is just an example, change it to fit your use case

--- a/services/file.py
+++ b/services/file.py
@@ -1,6 +1,6 @@
 import os
 from io import BufferedReader
-from typing import Optional
+
 from fastapi import UploadFile
 import mimetypes
 from PyPDF2 import PdfReader
@@ -21,7 +21,7 @@ async def get_document_from_file(file: UploadFile) -> Document:
     return doc
 
 
-def extract_text_from_filepath(filepath: str, mimetype: Optional[str] = None) -> str:
+def extract_text_from_filepath(filepath: str, mimetype: str | None = None) -> str:
     """Return the text content of a file given its filepath."""
 
     if mimetype is None:
@@ -81,7 +81,7 @@ def extract_text_from_file(file: BufferedReader, mimetype: str) -> str:
     else:
         # Unsupported file type
         file.close()
-        raise ValueError("Unsupported file type: {}".format(mimetype))
+        raise ValueError(f"Unsupported file type: {mimetype}")
 
     file.close()
     return extracted_text

--- a/services/openai.py
+++ b/services/openai.py
@@ -1,4 +1,3 @@
-from typing import List
 import openai
 
 
@@ -6,7 +5,7 @@ from tenacity import retry, wait_random_exponential, stop_after_attempt
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
-def get_embeddings(texts: List[str]) -> List[List[float]]:
+def get_embeddings(texts: list[str]) -> list[list[float]]:
     """
     Embed texts using OpenAI's ada model.
 

--- a/tests/datastore/providers/qdrant/test_qdrant_datastore.py
+++ b/tests/datastore/providers/qdrant/test_qdrant_datastore.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import pytest
 import qdrant_client
 from qdrant_client.http.models import PayloadSchemaType
@@ -14,7 +12,7 @@ from models.models import (
 )
 
 
-def create_embedding(non_zero_pos: int, size: int) -> List[float]:
+def create_embedding(non_zero_pos: int, size: int) -> list[float]:
     vector = [0.0] * size
     vector[non_zero_pos % size] = 1.0
     return vector
@@ -33,7 +31,7 @@ def client() -> qdrant_client.QdrantClient:
 
 
 @pytest.fixture
-def initial_document_chunks() -> Dict[str, List[DocumentChunk]]:
+def initial_document_chunks() -> dict[str, list[DocumentChunk]]:
     first_doc_chunks = [
         DocumentChunk(
             id=f"first-doc-{i}",
@@ -49,7 +47,7 @@ def initial_document_chunks() -> Dict[str, List[DocumentChunk]]:
 
 
 @pytest.fixture
-def document_chunks() -> Dict[str, List[DocumentChunk]]:
+def document_chunks() -> dict[str, list[DocumentChunk]]:
     first_doc_chunks = [
         DocumentChunk(
             id=f"first-doc_{i}",


### PR DESCRIPTION
Upgrade syntax to reflect a minimum Python version of 3.10.

Applied automatically using https://github.com/asottile/pyupgrade and the following command:
```
pyupgrade --py310-plus $(find . -name '*.py')
```

Main benefits are
* using built-ins as generic types (`typing.List` -> `list`), which is a small simplification
* replace `Optional[mytype]` with `mytype| None`, which is a little clearer