### PR TITLE
fix tokenization bug

### DIFF
--- a/services/chunks.py
+++ b/services/chunks.py
@@ -79,11 +79,11 @@ def get_text_chunks(text: str, chunk_token_size: Optional[int]) -> List[str]:
             chunk_text = chunk_text[: last_punctuation + 1]
 
         # Remove any newline characters and strip any leading or trailing whitespace
-        chunk_text = chunk_text.replace("\n", " ").strip()
+        chunk_text_to_append = chunk_text.replace("\n", " ").strip()
 
-        if len(chunk_text) > MIN_CHUNK_LENGTH_TO_EMBED:
+        if len(chunk_text_to_append) > MIN_CHUNK_LENGTH_TO_EMBED:
             # Append the chunk text to the list of chunks
-            chunks.append(chunk_text)
+            chunks.append(chunk_text_to_append)
 
         # Remove the tokens corresponding to the chunk text from the remaining tokens
         tokens = tokens[len(tokenizer.encode(chunk_text, disallowed_special=())) :]


### PR DESCRIPTION
Line 81-89:
``chunk_text = chunk_text.replace("\n", " ").strip()``
``if len(chunk_text) > MIN_CHUNK_LENGTH_TO_EMBED:``
``    chunks.append(chunk_text)``
``tokens = tokens[len(tokenizer.encode(chunk_text, disallowed_special=())) :]``

You replace a ``\n`` in the ``chunk_text`` with a space. However, you have changed the tokenization of text when you do this replacement. For example, ``.\n\n\`` will be encoded into one token 382 from the tokenizer while ``.  `` will be encoded into [13, 256]. When you encode the sentence again, the length of the encoded chunk_text will change because the encoding for ``.\n\n`` and ``.  `` are different. Then when you do the list sharding again via ``tokens = tokens[len(tokenizer.encode(chunk_text, disallowed_special=())) :]``, the index you get from ``len(tokenizer.encode(chunk_text, disallowed_special=()))`` is not the correct starting index for the first word in the next sentence after the punctuation. Thus, some tokens from original text will be missed during the chunking process.