### PR TITLE
Add docker compose install link and fix the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,9 @@ You can run Weaviate in 4 ways:
 - **Self-hosted** – with a Docker container
 
   To set up a Weaviate instance with Docker:
-
-  1.  Download a `docker-compose.yml` file with this `curl` command:
+  1. [Install Docker](https://docs.docker.com/engine/install/) on your local machine if it is not already installed.
+  2. [Install the Docker Compose Plugin](https://docs.docker.com/compose/install/)
+  3.  Download a `docker-compose.yml` file with this `curl` command:
 
       ```
       curl -o docker-compose.yml "https://configuration.weaviate.io/v2/docker-compose/docker-compose.yml?modules=standalone&runtime=docker-compose&weaviate_version=v1.18.0"
@@ -260,9 +261,9 @@ You can run Weaviate in 4 ways:
 
       Alternatively, you can use Weaviate's docker compose [configuration tool](https://weaviate.io/developers/weaviate/installation/docker-compose) to generate your own `docker-compose.yml` file.
 
-  2.  Run `docker-compose up -d` to spin up a Weaviate instance.
+  4.  Run `docker compose up -d` to spin up a Weaviate instance.
 
-      > To shut it down, run `docker-compose down`.
+      > To shut it down, run `docker compose down`.
 
 - **Self-hosted** – with a Kubernetes cluster
 


### PR DESCRIPTION
`docker-compose` will get deprecated and is not  supported in latest versions so we should instead use `docker compose`

> From the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions.
> 
> Make sure you switch to [Compose V2](https://docs.docker.com/compose/compose-file/) with the docker compose CLI plugin or by activating the Use Docker Compose V2 setting in Docker Desktop. For more information, see the [Evolution of Compose](https://docs.docker.com/compose/compose-v2/)