### PR TITLE
Calling /upsert-file should be setting source as type 'file'

### DIFF
--- a/services/file.py
+++ b/services/file.py
@@ -8,7 +8,7 @@ import docx2txt
 import csv
 import pptx
 
-from models.models import Document, DocumentMetadata
+from models.models import Document, DocumentMetadata, Source
 
 
 async def get_document_from_file(file: UploadFile) -> Document:
@@ -16,7 +16,7 @@ async def get_document_from_file(file: UploadFile) -> Document:
     print(f"extracted_text:")
     # get metadata
     metadata = DocumentMetadata()
-    metadata.source = "file"
+    metadata.source = Source.file
     doc = Document(text=extracted_text, metadata=metadata)
 
     return doc

--- a/services/file.py
+++ b/services/file.py
@@ -16,6 +16,7 @@ async def get_document_from_file(file: UploadFile) -> Document:
     print(f"extracted_text:")
     # get metadata
     metadata = DocumentMetadata()
+    metadata.source = "file"
     doc = Document(text=extracted_text, metadata=metadata)
 
     return doc


### PR DESCRIPTION
I believe /upsert-file should be setting the source to 'file' type. Currently it is left as null and hence results in an error during query as follows:

Error: 1 validation error for DocumentChunkWithScore
metadata -> source
  value is not a valid enumeration member; permitted: 'email', 'file', 'chat' (type=type_error.enum; enum_values=[<Source.email: 'email'>, <Source.file: 'file'>, <Source.chat: 'chat'>])

Backend datastore is redis-stack-server