### PR TITLE
Rename Weaviate scope env variable in docs to match the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ If you enabled OIDC authentication for your Weaviate instance (recommended for W
 | ------------------- | -------- | ------------------------------ |
 | `WEAVIATE_USERNAME` | Yes      | Your OIDC or WCS username      |
 | `WEAVIATE_PASSWORD` | Yes      | Your OIDC or WCS password      |
-| `WEAVIATE_SCOPES`   | Optional | Space-separated list of scopes |
+| `WEAVIATE_SCOPE`    | Optional | Space-separated list of scopes |
 
 Learn more about [authentication in Weaviate](https://weaviate.io/developers/weaviate/configuration/authentication#overview) and the [Python client authentication](https://weaviate-python-client.readthedocs.io/en/stable/weaviate.auth.html).
 


### PR DESCRIPTION
The environment variable's expected name is `WEAVIATE_SCOPE`, not `WEAVIATE_SCOPES`. Although it is extracted and used as `WEAVIATE_SCOPES` in the code, I have renamed the docs to `WEAVIATE_SCOPE` to keep the code backward compatible.