### PR TITLE
Increase the default timeout in QdrantClient

### DIFF
--- a/datastore/providers/qdrant_datastore.py
+++ b/datastore/providers/qdrant_datastore.py
@@ -51,6 +51,7 @@ class QdrantDataStore(DataStore):
             grpc_port=int(QDRANT_GRPC_PORT),
             api_key=QDRANT_API_KEY,
             prefer_grpc=True,
+            timeout=10,
         )
         self.collection_name = collection_name or QDRANT_COLLECTION
 


### PR DESCRIPTION
This PR changes the default timeout in `QdrantClient` to 10 seconds. In some scenarios, with the retrieval plugin and Qdrant instance deployed on low-end machines and different regions, the default one was causing some issues.