### PR TITLE
Update ai-plugin.json

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -15,5 +15,5 @@
   },
   "logo_url": "https://your-app-url.com/.well-known/logo.png",
   "contact_email": "hello@contact.com", 
-  "legal_info_url": "hello@legal.com"
+  "legal_info_url": "http://example.com/legal-info"
 }


### PR DESCRIPTION
In the `ai-plugin.json` file, the `legal_info_url` field should contain a URL, but it currently contains an email address.

```json
{
  ...
  "legal_info_url": "http://example.com/legal-info"
}

~ Suggested by GPT-4 (8K context)