### PR TITLE
Redis improvements and cleanup

### DIFF
--- a/datastore/providers/redis_datastore.py
+++ b/datastore/providers/redis_datastore.py
@@ -320,8 +320,7 @@ class RedisDataStore(DataStore):
                     id=doc_json["metadata"]["document_id"],
                     score=doc.score,
                     text=doc_json["text"],
-                    metadata=doc_json["metadata"],
-                    embedding=doc_json["embedding"]
+                    metadata=doc_json["metadata"]
                 )
                 query_results.append(result)
 


### PR DESCRIPTION
This PR includes a few improvements to stabilize the use of Redis as a vector datastore.

1. Adds validation to make sure RediSearch >= 2.6 and RedisJSON >= 2.4 are installed in the Redis Server. (https://github.com/openai/chatgpt-retrieval-plugin/issues/26 and https://github.com/openai/chatgpt-retrieval-plugin/issues/17)
2. Removed async semaphore usage in favor of pipelines.
3. Updated the delete method to use `scan_iter` instead of `keys`.
4. Adds the embeddings to the response object: https://github.com/openai/chatgpt-retrieval-plugin/issues/35