### PR TITLE
substitute dict to tuple

### DIFF
--- a/datastore/providers/pinecone_datastore.py
+++ b/datastore/providers/pinecone_datastore.py
@@ -80,13 +80,15 @@ class PineconeDataStore(DataStore):
             doc_ids.append(doc_id)
             print(f"Upserting document_id: {doc_id}")
             for chunk in chunk_list:
-                # Create a vector tuple of (id, embedding, metadata)
+                # Create a vector dict with keys {id, embedding, metadata}
                 # Convert the metadata object to a dict with unix timestamps for dates
                 pinecone_metadata = self._get_pinecone_metadata(chunk.metadata)
                 # Add the text and document id to the metadata dict
                 pinecone_metadata["text"] = chunk.text
                 pinecone_metadata["document_id"] = doc_id
-                vector = (chunk.id, chunk.embedding, pinecone_metadata)
+                vector = {"id": chunk.id,
+                          "values": chunk.embedding,
+                          "metadata" : pinecone_metadata}
                 vectors.append(vector)
 
         # Split the vectors list into batches of the specified size


### PR DESCRIPTION
Using dict make the code more readable and easier to modify without changing the index settings.