### PR TITLE
fix tiktoken issue with rust on docker build(#131)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.10 as requirements-stage
 
 WORKDIR /tmp
 
+RUN apt-get update
+RUN pip install --upgrade pip
+
 RUN pip install poetry
 
 COPY ./pyproject.toml ./poetry.lock* /tmp/
@@ -11,6 +14,10 @@ COPY ./pyproject.toml ./poetry.lock* /tmp/
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 FROM python:3.10
+
+RUN apt-get install -y gcc curl
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+SHELL ["bash", "-lc"]
 
 WORKDIR /code
 


### PR DESCRIPTION
### Description
This PR update the DOCKER file to fix the tiktoken issue with rust on docker build.

Error: Building wheel for tiktoken (pyproject.toml) did not run successfully.

### Issue

Resolves #131 