### PR TITLE
Do some README refactor after LlamaIndex as a Datastore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Follow these steps to quickly set up and run the ChatGPT Retrieval Plugin:
    export REDIS_DOC_PREFIX=<your_redis_doc_prefix>
    export REDIS_DISTANCE_METRIC=<your_redis_distance_metric>
    export REDIS_INDEX_TYPE=<your_redis_index_type>
+   
+   # Llama
+   export LLAMA_INDEX_TYPE=<gpt_vector_index_type>
+   export LLAMA_INDEX_JSON_PATH=<path_to_saved_index_json_file>
+   export LLAMA_QUERY_KWARGS_JSON_PATH=<path_to_saved_query_kwargs_json_file>
+   export LLAMA_RESPONSE_MODE=<response_mode_for_query> 
    ```
 
 9. Run the API locally: `poetry run start`
@@ -433,3 +439,6 @@ We would like to extend our gratitude to the following contributors for their co
 - [Redis](https://redis.io/)
   - [spartee](https://github.com/spartee)
   - [tylerhutcherson](https://github.com/tylerhutcherson)
+- [LlamaIndex](https://github.com/jerryjliu/llama_index)
+  - [jerryjliu](https://github.com/jerryjliu)
+  - [Disiok](https://github.com/Disiok)

--- a/docs/providers/llama/setup.md
+++ b/docs/providers/llama/setup.md
@@ -16,20 +16,20 @@ with ChatGPT and your external data.
 
 **Retrieval App Environment Variables**
 
-| Name             | Required | Description                            |
-| ---------------- | -------- | -------------------------------------- |
+| Name             | Required | Description                         |
+|------------------|----------|-------------------------------------|
 | `DATASTORE`      | Yes      | Datastore name. Set this to `llama` |
-| `BEARER_TOKEN`   | Yes      | Your secret token                      |
-| `OPENAI_API_KEY` | Yes      | Your OpenAI API key                    |
+| `BEARER_TOKEN`   | Yes      | Your secret token                   |
+| `OPENAI_API_KEY` | Yes      | Your OpenAI API key                 |
 
 **Llama Datastore Environment Variables**
 
-| Name                            | Required | Description                                                        | Default            |
-| ------------------------------- | -------- | ------------------------------------------------------------------ | ------------------ |
-| `LLAMA_INDEX_TYPE`              | Optional | Index type (see below for details)                                 | `simple_dict`      |
-| `LLAMA_INDEX_JSON_PATH`         | Optional | Path to saved Index json file                                      | None               |
-| `LLAMA_QUERY_KWARGS_JSON_PATH`         | Optional | Path to saved query kwargs json file                                      | None               |
-| `LLAMA_RESPONSE_MODE`           | Optional | Response mode for query                                            | `no_text`          | 
+| Name                           | Required | Description                          | Default       |
+|--------------------------------|----------|--------------------------------------|---------------|
+| `LLAMA_INDEX_TYPE`             | Optional | Index type (see below for details)   | `simple_dict` |
+| `LLAMA_INDEX_JSON_PATH`        | Optional | Path to saved Index json file        | None          |
+| `LLAMA_QUERY_KWARGS_JSON_PATH` | Optional | Path to saved query kwargs json file | None          |
+| `LLAMA_RESPONSE_MODE`          | Optional | Response mode for query              | `no_text`     | 
 
 
 **Different Index Types**


### PR DESCRIPTION
Hi there.
As I try to add a new datastore [AnalyticDB](https://github.com/openai/chatgpt-retrieval-plugin/pull/147).  I find that the README is not suitable updated after Llama index merged. So this commit do some refactor. Add environment variables export related to Llama and and contributors info.  Also format the table let it looks better.