### PR TITLE
Move `servers` field to top level in OpenAPI document

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: Retrieval Plugin API
   description: A retrieval API for querying and filtering documents based on natural language queries and metadata
   version: 1.0.0
-  servers:
-    - url: https://your-app-url.com
+servers:
+  - url: https://your-app-url.com
 paths:
   /query:
     post:


### PR DESCRIPTION
This PR addresses a minor issue with the current OpenAPI document structure. The servers field was previously placed under the info field, which does not conform to the OpenAPI specification.

Changes:

Move the servers field to the top level of the OpenAPI document, in accordance with the specification.

Impact:

Improved adherence to the OpenAPI specification, ensuring better compatibility with tools and libraries relying on the standard structure.