### PR TITLE
Convert datastore environment variable to lowercase for case-insensitive matching

### DIFF
--- a/datastore/factory.py
+++ b/datastore/factory.py
@@ -4,9 +4,10 @@ import os
 
 async def get_datastore() -> DataStore:
     datastore = os.environ.get("DATASTORE")
-    assert datastore is not None
+    assert datastore is not None, "The DATASTORE environment variable must be set."
 
-    match datastore:
+    datastore_lower = datastore.lower()
+    match datastore_lower:
         case "llama":
             from datastore.providers.llama_datastore import LlamaDataStore
             return LlamaDataStore()


### PR DESCRIPTION
Hi there,

I've created this merge request to address an issue where some users tend to mix upper and lower case letters in the DATASTORE environment variable. By converting the environment variable to lowercase before matching, we can ensure that the code functions correctly regardless of the letter casing provided by the user. This should help prevent potential issues caused by case sensitivity.

Please review the changes and let me know if you have any suggestions or concerns. Thank you!
