### PR TITLE
Fix dynamic redis key in redis_datastore.py

### DIFF
--- a/datastore/providers/redis_datastore.py
+++ b/datastore/providers/redis_datastore.py
@@ -141,7 +141,7 @@ class RedisDataStore(DataStore):
         Returns:
             str: JSON key string.
         """
-        return f"doc:{document_id}:chunk:{chunk_id}"
+        return f"{REDIS_DOC_PREFIX}:{document_id}:chunk:{chunk_id}"
 
     @staticmethod
     def _escape(value: str) -> str:


### PR DESCRIPTION
The PR is trying to fix the wrong redis key in the query api. When I was using provider redis and updated `REDIS_DOC_PREFIX`, the  index in redisearch was created as expected, however doc prefix is hard coded in upsert api, it should be controlled by `REDIS_DOC_PREFIX`.
Let me know if something wrong, Thank you.

````
>FT.INFO MY_INDEX_NAME

 5) index_definition
 6) 1) key_type
    2) JSON
    3) prefixes
    4) 1) MY_PREFIX
    5) default_score
    6) "1"

````

````
127.0.0.1:6379> keys *
2) "doc:198850882159:chunk:198850882159_0"
````