### PR TITLE
Fixes qdrant delete return value

### DIFF
--- a/datastore/providers/qdrant_datastore.py
+++ b/datastore/providers/qdrant_datastore.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from grpc._channel import _InactiveRpcError
 from qdrant_client.http.exceptions import UnexpectedResponse
-from qdrant_client.http.models import PayloadSchemaType
+from qdrant_client.http.models import PayloadSchemaType, UpdateStatus
 
 from datastore.datastore import DataStore
 from models.models import (
@@ -126,7 +126,7 @@ class QdrantDataStore(DataStore):
             collection_name=self.collection_name,
             points_selector=points_selector,  # type: ignore
         )
-        return "COMPLETED" == response.status
+        return response.status in [UpdateStatus.ACKNOWLEDGED, UpdateStatus.COMPLETED]
 
     def _convert_document_chunk_to_point(
         self, document_chunk: DocumentChunk

--- a/tests/datastore/providers/qdrant/test_qdrant_datastore.py
+++ b/tests/datastore/providers/qdrant/test_qdrant_datastore.py
@@ -278,3 +278,12 @@ async def test_delete_removes_all(
     await qdrant_datastore.delete(delete_all=True)
 
     assert 0 == client.count(collection_name="documents").count
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_true_on_success(
+        qdrant_datastore
+):
+    success = await qdrant_datastore.delete(delete_all=True)
+
+    assert True is success


### PR DESCRIPTION
The `qdrant_datastore.delete(...)` implementation always returns false because the check for completion is faulty. This not only makes the `/delete` endpoint return an incorrect result, but also makes other endpoints fail with an unspecified 500 server error (see linked issue).

Fixes https://github.com/openai/chatgpt-retrieval-plugin/issues/171

### Testing

**Manual test:**

Setup: Use an empty qdrant testing DB
1. Call the `/delete` endpoint with `delete_all: true`
2. Response body should contain `success: true`

Also, added a unit test to ensure correctness; test fails without the change in implementation.
(I don't think we need to test the reverse case (qdrant failure), as the qdrant client is supposed to throw an error in such a case.)