### PR TITLE
chore: update servers field in openapi.yaml

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: Retrieval Plugin API
   description: A retrieval API for querying and filtering documents based on natural language queries and metadata
   version: 1.0.0
-  servers:
-    - url: https://your-app-url.com
+servers:
+  - url: https://your-app-url.com
 paths:
   /query:
     post:


### PR DESCRIPTION
The `servers` field should be at the top level of the openapi spec to match the openapi spec and openai docs.

https://swagger.io/specification/

https://platform.openai.com/docs/plugins/getting-started/plugin-manifest