### PR TITLE
Add a option to save Llama index automatically

### DIFF
--- a/docs/providers/llama/setup.md
+++ b/docs/providers/llama/setup.md
@@ -28,6 +28,7 @@ with ChatGPT and your external data.
 | ------------------------------- | -------- | ------------------------------------------------------------------ | ------------------ |
 | `LLAMA_INDEX_TYPE`              | Optional | Index type (see below for details)                                 | `simple_dict`      |
 | `LLAMA_INDEX_JSON_PATH`         | Optional | Path to saved Index json file                                      | None               |
+| `LLAMA_INDEX_AUTO_SAVE`         | Optional | Save index automatically when index is added or deleted            | None               |
 | `LLAMA_QUERY_KWARGS_JSON_PATH`         | Optional | Path to saved query kwargs json file                                      | None               |
 | `LLAMA_RESPONSE_MODE`           | Optional | Response mode for query                                            | `no_text`          | 
 

--- a/services/chunks.py
+++ b/services/chunks.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List, Optional, Tuple
 import uuid
 from models.models import Document, DocumentChunk, DocumentChunkMetadata
@@ -12,7 +13,7 @@ tokenizer = tiktoken.get_encoding(
 )  # The encoding scheme to use for tokenization
 
 # Constants
-CHUNK_SIZE = 200  # The target size of each text chunk in tokens
+CHUNK_SIZE = int(os.environ.get('DOCUMENT_CHUNK_SIZE', 200)) # The target size of each text chunk in tokens
 MIN_CHUNK_SIZE_CHARS = 350  # The minimum size of each text chunk in characters
 MIN_CHUNK_LENGTH_TO_EMBED = 5  # Discard chunks shorter than this
 EMBEDDINGS_BATCH_SIZE = 128  # The number of embeddings to request at a time


### PR DESCRIPTION
I add an option `LLAMA_INDEX_AUTO_SAVE` as an environment variable to save Llama index automatically.

If the below option is set, the datastore save index automatically when index is added or deleted 

```sh
export LLAMA_INDEX_AUTO_SAVE=True
```

I tested some prototypes but it's very annoying I have to upset many documents every time.

This option is very useful to test prototypes.