### PR TITLE
Fix inconsistent Weaviate env variable handling

### DIFF
--- a/datastore/providers/weaviate_datastore.py
+++ b/datastore/providers/weaviate_datastore.py
@@ -26,7 +26,7 @@ WEAVIATE_PORT = os.environ.get("WEAVIATE_PORT", "8080")
 WEAVIATE_USERNAME = os.environ.get("WEAVIATE_USERNAME", None)
 WEAVIATE_PASSWORD = os.environ.get("WEAVIATE_PASSWORD", None)
 WEAVIATE_SCOPES = os.environ.get("WEAVIATE_SCOPES", "offline_access")
-WEAVIATE_INDEX = os.environ.get("WEAVIATE_INDEX", "OpenAIDocument")
+WEAVIATE_CLASS = os.environ.get("WEAVIATE_CLASS", "OpenAIDocument")
 
 WEAVIATE_BATCH_SIZE = int(os.environ.get("WEAVIATE_BATCH_SIZE", 20))
 WEAVIATE_BATCH_DYNAMIC = os.environ.get("WEAVIATE_BATCH_DYNAMIC", False)


### PR DESCRIPTION
Looks like the recent PR #191 had a small error in the ENV variable rename from `WEAVIATE_INDEX` to `WEAVIATE_CLASS`. Probably due to a bad conflict resolution.

Before: `NameError: name 'WEAVIATE_CLASS' is not defined`
<details>
<summary><code>poetry run start</code></summary>

```sh
INFO:     Will watch for changes in these directories: ['/chatgpt-retrieval-plugin']
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [38217] using StatReload
INFO:     Started server process [38239]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/.poetry/cache/virtualenvs/chatgpt-retrieval-plugin-KUDb61zQ-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 671, in lifespan
    async with self.lifespan_context(app):
  File "/.poetry/cache/virtualenvs/chatgpt-retrieval-plugin-KUDb61zQ-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/.poetry/cache/virtualenvs/chatgpt-retrieval-plugin-KUDb61zQ-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 648, in startup
    await handler()
  File "/chatgpt-retrieval-plugin/server/main.py", line 151, in startup
    datastore = await get_datastore()
  File "/chatgpt-retrieval-plugin/datastore/factory.py", line 19, in get_datastore
    from datastore.providers.weaviate_datastore import WeaviateDataStore
  File "/chatgpt-retrieval-plugin/datastore/providers/weaviate_datastore.py", line 37, in <module>
    "class": WEAVIATE_CLASS,
NameError: name 'WEAVIATE_CLASS' is not defined

ERROR:    Application startup failed. Exiting.

```
</details>

After: starts successfully
<details>
<summary><code>poetry run start</code></summary>

```sh
INFO:     Will watch for changes in these directories: ['/chatgpt-retrieval-plugin']
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [38391] using StatReload
INFO:     Started server process [38417]
INFO:     Waiting for application startup.
2023-04-25 23:52:09.161 | DEBUG    | datastore.providers.weaviate_datastore:__init__:114 - Connecting to weaviate instance at http://127.0.0.1:8080 with credential type NoneType
2023-04-25 23:52:09.174 | DEBUG    | datastore.providers.weaviate_datastore:__init__:130 - Found index OpenAIDocument with properties {'created_at', 'author', 'text', 'chunk_id', 'document_id', 'url', 'source', 'source_id'}
2023-04-25 23:52:09.175 | DEBUG    | datastore.providers.weaviate_datastore:__init__:133 - Will reuse this schema
INFO:     Application startup complete.

```