### PR TITLE
fix: modules loaded in stack solved by image

### DIFF
--- a/examples/docker/redis/docker-compose.yml
+++ b/examples/docker/redis/docker-compose.yml
@@ -2,9 +2,11 @@ version: "3.9"
 
 services:
   redis:
-    image: redis/redis-stack-server:latest
+    image: redis/redis-stack:latest
     ports:
       - "6379:6379"
+    environment:
+      - REDIS_ARGS=--requirepass redis-stack
     volumes:
         - redis_data:/data
     healthcheck:


### PR DESCRIPTION
this image has all modules installed and will solve the issue instead of separately loading modules i.e. for all people that could not follow and had led to errors who used the image currently in the repo. Redis-stack has search and rejson modules. Entered password with the default image to enable a proper config to be used during development.