### PR TITLE
Add Deploy to Render button

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,10 @@ Consider the benefits and drawbacks of each authentication method before choosin
 
 You can deploy your app to different cloud providers, depending on your preferences and requirements. However, regardless of the provider you choose, you will need to update two files in your app: [openapi.yaml](/.well-known/openapi.yaml) and [ai-plugin.json](/.well-known/ai-plugin.json). As outlined above, these files define the API specification and the AI plugin configuration for your app, respectively. You need to change the url field in both files to match the address of your deployed app.
 
+Render has a 1-click deploy option that automatically updates the url field in both files:
+
+[<img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" />](https://render.com/deploy?repo=https://github.com/render-examples/chatgpt-retrieval-plugin/tree/main)
+
 Before deploying your app, you might want to remove unused dependencies from your [pyproject.toml](/pyproject.toml) file to reduce the size of your app and improve its performance. Depending on the vector database provider you choose, you can remove the packages that are not needed for your specific provider. Refer to the respective documentation in the [`/docs/deployment/removing-unused-dependencies.md`](/docs/deployment/removing-unused-dependencies.md) file for information on removing unused dependencies for each provider.
 
 Instructions:


### PR DESCRIPTION
This adds the Deploy to Render button to the main README's deployment section, as suggested by @isafulf: https://github.com/openai/chatgpt-retrieval-plugin/pull/224#pullrequestreview-1431962956