### PR TITLE
goldretriever as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Instructions:
 - [Deploying to Fly.io](/docs/deployment/flyio.md)
 - [Deploying to Heroku](/docs/deployment/heroku.md)
 - [Deploying to Render](/docs/deployment/render.md)
-- [Deploying to Gold Retriever](/docs/deployment/goldretriever.md)
+- [Deploying with Gold Retriever](/docs/deployment/goldretriever.md)
 - [Other Deployment Options](/docs/deployment/other-options.md) (Azure Container Apps, Google Cloud Run, AWS Elastic Container Service, etc.)
 
 Once you have deployed your app, consider uploading an initial batch of documents using one of [these scripts](/scripts) or by calling the `/upsert` endpoint.

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Instructions:
 - [Deploying to Fly.io](/docs/deployment/flyio.md)
 - [Deploying to Heroku](/docs/deployment/heroku.md)
 - [Deploying to Render](/docs/deployment/render.md)
-- [Deploying with Gold Retriever](/docs/deployment/goldretriever.md)
+- [Deploying to Jina Cloud with Gold Retriever](/docs/deployment/goldretriever.md)
 - [Other Deployment Options](/docs/deployment/other-options.md) (Azure Container Apps, Google Cloud Run, AWS Elastic Container Service, etc.)
 
 Once you have deployed your app, consider uploading an initial batch of documents using one of [these scripts](/scripts) or by calling the `/upsert` endpoint.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This is a plugin for ChatGPT that enables semantic search and retrieval of perso
 
 The plugin uses OpenAI's `text-embedding-ada-002` embeddings model to generate embeddings of document chunks, and then stores and queries them using a vector database on the backend. As an open-source and self-hosted solution, developers can deploy their own Retrieval Plugin and register it with ChatGPT. The Retrieval Plugin supports several vector database providers, allowing developers to choose their preferred one from a list.
 
-A FastAPI server exposes the plugin's endpoints for upserting, querying, and deleting documents. Users can refine their search results by using metadata filters by source, date, author, or other criteria. The plugin can be hosted on any cloud platform that supports Docker containers, such as Fly.io, Heroku, Render, or Azure Container Apps. To keep the vector database updated with the latest documents, the plugin can process and store documents from various data sources continuously, using incoming webhooks to the upsert and delete endpoints. Tools like [Zapier](https://zapier.com) or [Make](https://www.make.com) can help configure the webhooks based on events or schedules.
+A FastAPI server exposes the plugin's endpoints for upserting, querying, and deleting documents. Users can refine their search results by using metadata filters by source, date, author, or other criteria. The plugin can be hosted on any cloud platform that supports Docker containers, such as Fly.io, Heroku, Render, Gold Retriever or Azure Container Apps. To keep the vector database updated with the latest documents, the plugin can process and store documents from various data sources continuously, using incoming webhooks to the upsert and delete endpoints. Tools like [Zapier](https://zapier.com) or [Make](https://www.make.com) can help configure the webhooks based on events or schedules.
 
 ### Memory Feature
 
@@ -418,6 +418,7 @@ Instructions:
 - [Deploying to Fly.io](/docs/deployment/flyio.md)
 - [Deploying to Heroku](/docs/deployment/heroku.md)
 - [Deploying to Render](/docs/deployment/render.md)
+- [Deploying to Gold Retriever](/docs/deployment/goldretriever.md)
 - [Other Deployment Options](/docs/deployment/other-options.md) (Azure Container Apps, Google Cloud Run, AWS Elastic Container Service, etc.)
 
 Once you have deployed your app, consider uploading an initial batch of documents using one of [these scripts](/scripts) or by calling the `/upsert` endpoint.

--- a/docs/deployment/goldretriever.md
+++ b/docs/deployment/goldretriever.md
@@ -1,0 +1,40 @@
+# Deploying to Gold Retriever
+
+[goldretriever](https://github.com/jina-ai/GoldRetriever) is an open-source CLI tool, powered by [jina](https://github.com/jina-ai/jina) and [docarray](https://github.com/docarray/docarray), that enables you to create and host ChatGPT retrieval plugins in a few simple steps.
+
+### Installation
+Ensure you have Python 3.8 or later:
+```shell
+pip install goldretriever 
+```
+
+### Deployment
+Deploy a plugin providing your OpenAI key:
+```shell
+goldretriever deploy --key <your openai key>
+```
+
+Store the "Gateway (Http)" URL and the Bearer token provided in the output.
+```shell
+╭──────────────────────── 🎉 Flow is available! ────────────────────────╮
+│                                                                       │
+│   ID               retrieval-plugin-<plugin id>                       │
+│   Gateway (Http)   https://retrieval-plugin-<plugin id>.wolf.jina.ai  │
+│   Dashboard        https://dashboard.wolf.jina.ai/flow/<plugin id>    │
+│                                                                       │
+╰───────────────────────────────────────────────────────────────────────╯
+Bearer token: <your bearer token>
+```
+
+### Data Indexing
+Gather relevant text data files (PDF, TXT, DOCX, PPTX, or MD) in a directory and index the data:
+```shell
+goldretriever index --data my_files
+```
+
+### Integration
+1. Go to OpenAI Plugins.
+2. Select "Develop your own plugin".
+3. Enter the "Gateway (Http)" URL and Bearer token from the deployment step.
+
+To learn more, feel free to visit [goldretriever](https://github.com/jina-ai/GoldRetriever) and take a look at this [blogpost](https://jina.ai/news/gold-retriever-let-chatgpt-talk-to-your-data/) that highlights one of the many ways you can use goldretriever.

--- a/docs/deployment/goldretriever.md
+++ b/docs/deployment/goldretriever.md
@@ -1,4 +1,4 @@
-# Deploying with Gold Retriever
+# Deploying to Jina Cloud with Gold Retriever
 
 [goldretriever](https://github.com/jina-ai/GoldRetriever) is an open-source CLI tool, powered by [jina](https://github.com/jina-ai/jina) and [docarray](https://github.com/docarray/docarray), that enables you to create and host ChatGPT retrieval plugins in a few simple steps.
 
@@ -37,4 +37,4 @@ goldretriever index --data my_files
 2. Select "Develop your own plugin".
 3. Enter the "Gateway (Http)" URL and Bearer token from the deployment step.
 
-To learn more, feel free to visit [goldretriever](https://github.com/jina-ai/GoldRetriever) and take a look at this [blogpost](https://jina.ai/news/gold-retriever-let-chatgpt-talk-to-your-data/) that highlights one of the many ways you can use goldretriever.
+To learn more, consider visiting [goldretriever](https://github.com/jina-ai/GoldRetriever) and reviewing our featured [blogpost](https://jina.ai/news/gold-retriever-let-chatgpt-talk-to-your-data/) and [video tutorial](https://www.youtube.com/watch?v=gQz-vuo8w5I), which highlight one of the many ways you can effectively use goldretriever.

--- a/docs/deployment/goldretriever.md
+++ b/docs/deployment/goldretriever.md
@@ -1,4 +1,4 @@
-# Deploying to Gold Retriever
+# Deploying with Gold Retriever
 
 [goldretriever](https://github.com/jina-ai/GoldRetriever) is an open-source CLI tool, powered by [jina](https://github.com/jina-ai/jina) and [docarray](https://github.com/docarray/docarray), that enables you to create and host ChatGPT retrieval plugins in a few simple steps.
 


### PR DESCRIPTION
Hi everyone,

I'm an engineer at Jina AI, we created a CLI tool [goldretriever](https://github.com/jina-ai/GoldRetriever) that uses [docarray](https://github.com/docarray/docarray) as a vectorstore and [jina](https://github.com/jina-ai/jina) cloud for deployment, and enables developers to create and host their own ChatGPT retrieval plugins in a few simple steps. 

Would be amazing to add it as a deployment option to your repo! 