### PR TITLE
Support chroma_server_host

### DIFF
--- a/datastore/providers/chroma_datastore.py
+++ b/datastore/providers/chroma_datastore.py
@@ -46,7 +46,7 @@ class ChromaDataStore(DataStore):
         if client:
             self._client = client
         else:
-            if in_memory:
+            if in_memory == "True":
                 settings = (
                     chromadb.config.Settings(
                         chroma_db_impl="duckdb+parquet",


### PR DESCRIPTION
This [line](https://github.com/openai/chatgpt-retrieval-plugin/blob/main/datastore/providers/chroma_datastore.py#L49) of code prevent using chroma_server_host