### PR TITLE
[Bugfix] Move `servers` block to root of OpenAPI object

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: Retrieval Plugin API
   description: A retrieval API for querying and filtering documents based on natural language queries and metadata
   version: 1.0.0
-  servers:
-    - url: https://your-app-url.com
+servers:
+  - url: https://your-app-url.com
 paths:
   /query:
     post:

--- a/local_server/openapi.yaml
+++ b/local_server/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: Retrieval Plugin API
   description: A retrieval API for querying and filtering documents based on natural language queries and metadata
   version: 1.0.0
-  servers:
-    - url: http://localhost:3333
+servers:
+  - url: http://localhost:3333
 paths:
   /query:
     post:


### PR DESCRIPTION
The OpenAPI specification [clearly states](https://spec.openapis.org/oas/v3.0.2#fixed-fields) that the `servers` object is in the root, not a child of `info`. The `examples/memory` YAML gets this right, but the `local_server` and main `.well-known` ones do not.

This isn't a huge breaking problem or anything, but it does prevent tools like `openapi-generator` from working cleanly without passing in `--skip-validate-spec`. This simple change fixes it.

Closes #5. Mentioned in #201.