### PR TITLE
[Documentation] Fix critical typos in postgres setup documentation

### DIFF
--- a/docs/providers/postgres/setup.md
+++ b/docs/providers/postgres/setup.md
@@ -34,7 +34,7 @@ docker pull ankane/pgvector
 ```
 
 ```bash
-docker run --name pgvector -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+docker run --name pgvector -e POSTGRES_PASSWORD=mysecretpassword -d ankane/pgvector
 ```
 
 Check PostgreSQL [official docker image](https://github.com/docker-library/docs/blob/master/postgres/README.md) for more options.
@@ -50,7 +50,7 @@ psql -h localhost -p 5432 -U postgres -d postgres -f examples/providers/supabase
 
 ```bash
 export PG_HOST=localhost
-export PG_PORT=54322
+export PG_PORT=5432
 export PG_PASSWORD=mysecretpassword
 ```
 


### PR DESCRIPTION
Fixing 2 critical typos in the setup documentation:
- First, the docker run command was running the regular `postgres` image and not the `pgvector` one.
- Second, the PG_PORT env variable had one too many 2's at the end. Making it not match the earlier setup. 

