### PR TITLE
[Enhancement] Fix error message in datastore/factory.py

### DIFF
--- a/datastore/factory.py
+++ b/datastore/factory.py
@@ -7,61 +7,60 @@ async def get_datastore() -> DataStore:
     assert datastore is not None
 
     match datastore:
-        case "chroma":
-            from datastore.providers.chroma_datastore import ChromaDataStore
-
-            return ChromaDataStore()
-        case "llama":
-            from datastore.providers.llama_datastore import LlamaDataStore
-
-            return LlamaDataStore()
-
-        case "pinecone":
-            from datastore.providers.pinecone_datastore import PineconeDataStore
-
-            return PineconeDataStore()
-        case "weaviate":
-            from datastore.providers.weaviate_datastore import WeaviateDataStore
-
-            return WeaviateDataStore()
-        case "milvus":
-            from datastore.providers.milvus_datastore import MilvusDataStore
-
-            return MilvusDataStore()
-        case "zilliz":
-            from datastore.providers.zilliz_datastore import ZillizDataStore
-
-            return ZillizDataStore()
-        case "redis":
-            from datastore.providers.redis_datastore import RedisDataStore
-
-            return await RedisDataStore.init()
-        case "qdrant":
-            from datastore.providers.qdrant_datastore import QdrantDataStore
-
-            return QdrantDataStore()
-        case "azuresearch":
-            from datastore.providers.azuresearch_datastore import AzureSearchDataStore
-
-            return AzureSearchDataStore()
-        case "supabase":
-            from datastore.providers.supabase_datastore import SupabaseDataStore
-
-            return SupabaseDataStore()
-        case "postgres":
-            from datastore.providers.postgres_datastore import PostgresDataStore
-
-            return PostgresDataStore()
         case "analyticdb":
             from datastore.providers.analyticdb_datastore import AnalyticDBDataStore
 
             return AnalyticDBDataStore()
+        case "azuresearch":
+            from datastore.providers.azuresearch_datastore import AzureSearchDataStore
+
+            return AzureSearchDataStore()
+        case "chroma":
+            from datastore.providers.chroma_datastore import ChromaDataStore
+
+            return ChromaDataStore()
         case "elasticsearch":
             from datastore.providers.elasticsearch_datastore import (
                 ElasticsearchDataStore,
             )
 
             return ElasticsearchDataStore()
+        case "llama":
+            from datastore.providers.llama_datastore import LlamaDataStore
+
+            return LlamaDataStore()
+        case "milvus":
+            from datastore.providers.milvus_datastore import MilvusDataStore
+
+            return MilvusDataStore()
+        case "pinecone":
+            from datastore.providers.pinecone_datastore import PineconeDataStore
+
+            return PineconeDataStore()
+        case "postgres":
+            from datastore.providers.postgres_datastore import PostgresDataStore
+
+            return PostgresDataStore()
+        case "qdrant":
+            from datastore.providers.qdrant_datastore import QdrantDataStore
+
+            return QdrantDataStore()
+        case "redis":
+            from datastore.providers.redis_datastore import RedisDataStore
+
+            return await RedisDataStore.init()
+        case "supabase":
+            from datastore.providers.supabase_datastore import SupabaseDataStore
+
+            return SupabaseDataStore()
+        case "weaviate":
+            from datastore.providers.weaviate_datastore import WeaviateDataStore
+
+            return WeaviateDataStore()
+        case "zilliz":
+            from datastore.providers.zilliz_datastore import ZillizDataStore
+
+            return ZillizDataStore()
         case _:
             raise ValueError(
                 f"Unsupported vector database: {datastore}. "

--- a/datastore/factory.py
+++ b/datastore/factory.py
@@ -65,5 +65,5 @@ async def get_datastore() -> DataStore:
         case _:
             raise ValueError(
                 f"Unsupported vector database: {datastore}. "
-                f"Try one of the following: llama, elasticsearch, pinecone, weaviate, milvus, zilliz, redis, azuresearch, or qdrant"
+                f"Try one of the following: analyticdb, azuresearch, chroma, elasticsearch, llama, milvus, pinecone, postgres, qdrant, redis, supabase, weaviate, or zilliz"
             )


### PR DESCRIPTION
* Add missing storage options in the error message displayed by `factory.py`
* Sort names alphabetically, so it's easier to check if the error message is in sync with the options available.

Previous error message:
> ValueError: Unsupported vector database: FooBar. Try one of the following: llama, elasticsearch, pinecone, weaviate, milvus, zilliz, redis, azuresearch, or qdrant

New error message:
> ValueError: Unsupported vector database: FooBar. Try one of the following: analyticdb, azuresearch, chroma, elasticsearch, llama, milvus, pinecone, postgres, qdrant, redis, supabase, weaviate, or zilliz