### PR TITLE
[Bugfix]: pinecone response to construct DocumentChunkWithScore

### DIFF
--- a/datastore/providers/pinecone_datastore.py
+++ b/datastore/providers/pinecone_datastore.py
@@ -159,7 +159,7 @@ class PineconeDataStore(DataStore):
                 result = DocumentChunkWithScore(
                     id=result.id,
                     score=score,
-                    text=metadata["text"] if metadata and "text" in metadata else None,
+                    text=str(metadata["text"]) if metadata and "text" in metadata else "",
                     metadata=metadata_without_text,
                 )
                 query_results.append(result)


### PR DESCRIPTION
When dealing with Pinecone occurs sporadically situations where `metadata["text"]` contains a datetime object somehow.

This raises an Internal Error since Pydantic is unable to create a DocumentChunkWithScore object.

We force the typing to str to fix this.

Example:
```
{'matches': [{'id': '68_1',
              'metadata': {'document_id': '68',
                           'text': datetime.date(2265, 12, 1)},
              'score': 0.760368824,
              'values': []},
```