### PR TITLE
[Bugfix]: Change env CHROMA_IN_MEMORY's type from str to bool before use it

### DIFF
--- a/datastore/providers/chroma_datastore.py
+++ b/datastore/providers/chroma_datastore.py
@@ -26,7 +26,7 @@ from models.models import (
 )
 from services.chunks import get_document_chunks
 
-CHROMA_IN_MEMORY = os.environ.get("CHROMA_IN_MEMORY", "True")
+CHROMA_IN_MEMORY = True if os.environ.get("CHROMA_IN_MEMORY", "True").lower() == "true" else False
 CHROMA_PERSISTENCE_DIR = os.environ.get("CHROMA_PERSISTENCE_DIR", "openai")
 CHROMA_HOST = os.environ.get("CHROMA_HOST", "http://127.0.0.1")
 CHROMA_PORT = os.environ.get("CHROMA_PORT", "8000")


### PR DESCRIPTION
*Short Description**:  In `chroma_datastore.py`, the os.getenv function returns the value of the `CHROMA_IN_MEMORY` environment variable as a string. Currently, in the `ChromaDataStore.__init__` method (specifically, the `in_memory` variable), it directly relies on this value for decision-making(e.g.: `if in_memory: ...`). However, since any non-empty string is evaluated as `True` in the `if` statement, it results in the program attempting to use in_memory storage even when the CHROMA_IN_MEMORY environment variable is set to "false".

**Issue(s) Linked**: #401 