### PR TITLE
[Bugfix]/Use default values for SIMILARITY and NUM_LINES for the Azure CosmosDB datastore provider-405

### DIFF
--- a/datastore/providers/azurecosmosdb_datastore.py
+++ b/datastore/providers/azurecosmosdb_datastore.py
@@ -27,6 +27,8 @@ AZCOSMOS_API = os.environ.get("AZCOSMOS_API", "mongo-vcore")
 AZCOSMOS_CONNSTR = os.environ.get("AZCOSMOS_CONNSTR")
 AZCOSMOS_DATABASE_NAME = os.environ.get("AZCOSMOS_DATABASE_NAME")
 AZCOSMOS_CONTAINER_NAME = os.environ.get("AZCOSMOS_CONTAINER_NAME")
+AZCOSMOS_SIMILARITY = os.environ.get("AZCOSMOS_SIMILARITY", "COS")
+AZCOSMOS_NUM_LISTS = os.environ.get("AZCOSMOS_NUM_LISTS", 100)
 assert AZCOSMOS_API is not None
 assert AZCOSMOS_CONNSTR is not None
 assert AZCOSMOS_DATABASE_NAME is not None
@@ -201,7 +203,7 @@ class AzureCosmosDBDataStore(DataStore):
                       
     """
     @staticmethod
-    async def create(num_lists, similarity) -> DataStore:
+    async def create(num_lists: int=AZCOSMOS_NUM_LISTS, similarity: str=AZCOSMOS_SIMILARITY) -> DataStore:
 
         # Create underlying data store based on the API definition.
         # Right now this only supports Mongo, but set up to support more.
@@ -211,6 +213,11 @@ class AzureCosmosDBDataStore(DataStore):
             apiStore = MongoStoreApi(mongoClient)
         else:
             raise NotImplementedError
+        if similarity not in ["COS", "L2", "IP"]:
+            raise ValueError(
+                f"Similarity {similarity} is not supported."
+                "Supported similarity metrics are COS, L2, and IP."
+            )
 
         await apiStore.ensure(num_lists, similarity)
         store = AzureCosmosDBDataStore(apiStore)

--- a/tests/datastore/providers/azurecosmosdb/test_azurecosmosdb_datastore.py
+++ b/tests/datastore/providers/azurecosmosdb/test_azurecosmosdb_datastore.py
@@ -79,6 +79,10 @@ def queries() -> List[QueryWithEmbedding]:
 async def azurecosmosdb_datastore() -> DataStore:
     return await AzureCosmosDBDataStore.create(num_lists=num_lists, similarity=similarity)
 
+@pytest.mark.asyncio
+async def test_invalid_similarity() -> None:
+    with pytest.raises(ValueError):
+        await AzureCosmosDBDataStore.create(num_lists=num_lists, similarity="INVALID")
 
 @pytest.mark.asyncio
 async def test_upsert(


### PR DESCRIPTION
*Short Description*: This PR fixes an issue where it's not possible to use the Azure CosmosDB datastore provider because it needs some default values for both similarity and num lines. Those values are provided as environment variables and have some default values in the code (in case the environment variables are not provided)