### PR TITLE
Add optional EMBEDDING_DIMENSION to get_embedding

### DIFF
--- a/services/openai.py
+++ b/services/openai.py
@@ -6,6 +6,7 @@ from loguru import logger
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 
 EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-large")
+EMBEDDING_DIMENSION = int(os.environ.get("EMBEDDING_DIMENSION", 256))
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
@@ -28,7 +29,7 @@ def get_embeddings(texts: List[str]) -> List[List[float]]:
 
     response = {}
     if deployment is None:
-        response = openai.Embedding.create(input=texts, model=EMBEDDING_MODEL)
+        response = openai.Embedding.create(input=texts, model=EMBEDDING_MODEL, dimension=EMBEDDING_DIMENSION)
     else:
         response = openai.Embedding.create(input=texts, deployment_id=deployment)
 


### PR DESCRIPTION
## Add optional EMBEDDING_DIMENSION to get_embedding

* **Type of PR**:`[Bugfix]`,  `[Enhancement]`


* **Short Description**: This PR makes it so that environment variable EMBEDDING_DIMENSION is used when creating embeddings, for both upsert and query. It is listed as bugfix because the current code does not accurately implement what's documented.


* **Issue(s) Linked**: Fixes #426
 

* **Branch**: `embedding-dimensions`


* **Code Changes**: Make sure the code changes are minimal, focused, and relevant to the issue or feature being addressed.x


* **Tests**: Admittedly, I have not added any tests. The only tests available are those on the datastores. Tests will be coming when I add MongoDB.


* **Documentation**: Importantly, this one line change puts code behavior in line with documentation so no changes were needed.
