### PR TITLE
fix: patch 4 critical security vulnerabilities

### DIFF
--- a/datastore/providers/postgres_datastore.py
+++ b/datastore/providers/postgres_datastore.py
@@ -112,27 +112,31 @@ class PostgresClient(PGClient):
         Deletes rows in the table that match the filter.
         """
 
-        filters = "WHERE"
+        conditions = []
         params = []
         if filter.document_id:
-            filters += " document_id = %s AND"
+            conditions.append("document_id = %s")
             params.append(filter.document_id)
         if filter.source:
-            filters += " source = %s AND"
+            conditions.append("source = %s")
             params.append(filter.source)
         if filter.source_id:
-            filters += " source_id = %s AND"
+            conditions.append("source_id = %s")
             params.append(filter.source_id)
         if filter.author:
-            filters += " author = %s AND"
+            conditions.append("author = %s")
             params.append(filter.author)
         if filter.start_date:
-            filters += " created_at >= %s AND"
+            conditions.append("created_at >= %s")
             params.append(filter.start_date)
         if filter.end_date:
-            filters += " created_at <= %s AND"
+            conditions.append("created_at <= %s")
             params.append(filter.end_date)
-        filters = filters[:-4]
+
+        if not conditions:
+            return
+
+        filters = "WHERE " + " AND ".join(conditions)
 
         with self.client.cursor() as cur:
             cur.execute(f"DELETE FROM {table} {filters}", params)

--- a/datastore/providers/postgres_datastore.py
+++ b/datastore/providers/postgres_datastore.py
@@ -113,20 +113,27 @@ class PostgresClient(PGClient):
         """
 
         filters = "WHERE"
+        params = []
         if filter.document_id:
-            filters += f" document_id = '{filter.document_id}' AND"
+            filters += " document_id = %s AND"
+            params.append(filter.document_id)
         if filter.source:
-            filters += f" source = '{filter.source}' AND"
+            filters += " source = %s AND"
+            params.append(filter.source)
         if filter.source_id:
-            filters += f" source_id = '{filter.source_id}' AND"
+            filters += " source_id = %s AND"
+            params.append(filter.source_id)
         if filter.author:
-            filters += f" author = '{filter.author}' AND"
+            filters += " author = %s AND"
+            params.append(filter.author)
         if filter.start_date:
-            filters += f" created_at >= '{filter.start_date}' AND"
+            filters += " created_at >= %s AND"
+            params.append(filter.start_date)
         if filter.end_date:
-            filters += f" created_at <= '{filter.end_date}' AND"
+            filters += " created_at <= %s AND"
+            params.append(filter.end_date)
         filters = filters[:-4]
 
         with self.client.cursor() as cur:
-            cur.execute(f"DELETE FROM {table} {filters}")
+            cur.execute(f"DELETE FROM {table} {filters}", params)
             self.client.commit()

--- a/scripts/process_zip/process_zip.py
+++ b/scripts/process_zip/process_zip.py
@@ -16,6 +16,16 @@ from services.pii_detection import screen_text_for_pii
 DOCUMENT_UPSERT_BATCH_SIZE = 50
 
 
+def _safe_extract(zip_file, target_dir):
+    """Extract zip contents after validating no path traversal attacks."""
+    target_dir = os.path.realpath(target_dir)
+    for member in zip_file.namelist():
+        member_path = os.path.realpath(os.path.join(target_dir, member))
+        if not member_path.startswith(target_dir + os.sep) and member_path != target_dir:
+            raise ValueError(f"Attempted path traversal in zip: {member}")
+    zip_file.extractall(target_dir)
+
+
 async def process_file_dump(
     filepath: str,
     datastore: DataStore,
@@ -23,9 +33,9 @@ async def process_file_dump(
     screen_for_pii: bool,
     extract_metadata: bool,
 ):
-    # create a ZipFile object and extract all the files into a directory named 'dump'
+    # create a ZipFile object and safely extract all the files into a directory named 'dump'
     with zipfile.ZipFile(filepath) as zip_file:
-        zip_file.extractall("dump")
+        _safe_extract(zip_file, "dump")
 
     documents = []
     skipped_files = []

--- a/server/main.py
+++ b/server/main.py
@@ -22,7 +22,8 @@ from models.models import DocumentMetadata, Source
 
 bearer_scheme = HTTPBearer()
 BEARER_TOKEN = os.environ.get("BEARER_TOKEN")
-assert BEARER_TOKEN is not None
+if not BEARER_TOKEN:
+    raise ValueError("BEARER_TOKEN environment variable is not set")
 
 
 def validate_token(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)):

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 from typing import Optional
 import uvicorn
 from fastapi import FastAPI, File, Form, HTTPException, Depends, Body, UploadFile
@@ -25,7 +26,7 @@ assert BEARER_TOKEN is not None
 
 
 def validate_token(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)):
-    if credentials.scheme != "Bearer" or credentials.credentials != BEARER_TOKEN:
+    if credentials.scheme != "Bearer" or not secrets.compare_digest(credentials.credentials, BEARER_TOKEN):
         raise HTTPException(status_code=401, detail="Invalid or missing token")
     return credentials
 

--- a/services/file.py
+++ b/services/file.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from io import BufferedReader
 from typing import Optional
 from fastapi import UploadFile
@@ -98,11 +99,12 @@ async def extract_text_from_form_file(file: UploadFile):
 
     file_stream = await file.read()
 
-    temp_file_path = "/tmp/temp_file"
-
-    # write the file to a temporary location
-    with open(temp_file_path, "wb") as f:
-        f.write(file_stream)
+    # write the file to a secure temporary location
+    with tempfile.NamedTemporaryFile(
+        delete=False, suffix=os.path.splitext(file.filename or "")[1]
+    ) as tmp:
+        tmp.write(file_stream)
+        temp_file_path = tmp.name
 
     try:
         extracted_text = extract_text_from_filepath(temp_file_path, mimetype)


### PR DESCRIPTION
## Summary

This PR fixes 4 security vulnerabilities identified in the codebase:

- **PLUGIN-01 — SQL Injection** in `postgres_datastore.py` `delete_by_filters`
- **PLUGIN-06 — Zip Slip** path traversal in `process_zip.py`
- **PLUGIN-03 — Hardcoded temp file path** race condition in `services/file.py`
- **PLUGIN-07 — Timing side-channel** in bearer token comparison in `server/main.py`

## Changes

### 1. SQL Injection in `delete_by_filters` (`datastore/providers/postgres_datastore.py`)

**Before (vulnerable):** Filter values interpolated directly into SQL via f-strings.
```python
filters += f" document_id = '{filter.document_id}' AND"
# ...
cur.execute(f"DELETE FROM {table} {filters}")
```

**After (fixed):** All filter values use parameterized `%s` placeholders passed via a `params` list.
```python
filters += " document_id = %s AND"
params.append(filter.document_id)
# ...
cur.execute(f"DELETE FROM {table} {filters}", params)
```

The table name remains from config (not user input). All six user-controllable filter fields (`document_id`, `source`, `source_id`, `author`, `start_date`, `end_date`) are now parameterized.

### 2. Zip Slip path traversal (`scripts/process_zip/process_zip.py`)

**Before (vulnerable):** `zip_file.extractall("dump")` with no member path validation.

**After (fixed):** Added `_safe_extract()` that resolves each member's real path and rejects any that escape the target directory:
```python
def _safe_extract(zip_file, target_dir):
    target_dir = os.path.realpath(target_dir)
    for member in zip_file.namelist():
        member_path = os.path.realpath(os.path.join(target_dir, member))
        if not member_path.startswith(target_dir + os.sep) and member_path != target_dir:
            raise ValueError(f"Attempted path traversal in zip: {member}")
    zip_file.extractall(target_dir)
```

### 3. Hardcoded temp file path (`services/file.py`)

**Before (vulnerable):** All uploads wrote to the same `/tmp/temp_file`, creating a race condition (TOCTOU) and predictable path.
```python
temp_file_path = "/tmp/temp_file"
with open(temp_file_path, "wb") as f:
    f.write(file_stream)
```

**After (fixed):** Uses `tempfile.NamedTemporaryFile` for unique, unpredictable temp files with correct extension:
```python
with tempfile.NamedTemporaryFile(
    delete=False, suffix=os.path.splitext(file.filename or "")[1]
) as tmp:
    tmp.write(file_stream)
    temp_file_path = tmp.name
```

### 4. Timing side-channel in token comparison (`server/main.py`)

**Before (vulnerable):** Direct `!=` comparison leaks token length/content via timing.
```python
credentials.credentials != BEARER_TOKEN
```

**After (fixed):** Constant-time comparison via `secrets.compare_digest`:
```python
not secrets.compare_digest(credentials.credentials, BEARER_TOKEN)
```

## Test plan

- [ ] Verify `delete_by_filters` works with various filter combinations against a Postgres instance
- [ ] Verify zip extraction rejects archives containing `../../etc/passwd` style paths
- [ ] Verify concurrent file uploads don't overwrite each other's temp files
- [ ] Verify valid bearer tokens still authenticate successfully
- [ ] Verify invalid bearer tokens are still rejected